### PR TITLE
Pins container image hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:stable
+# debian:buster 2021-02-10
+FROM debian@sha256:1092695e843ad975267131f27a2b523128c4e03d2d96574bbdd7cf949ed51475
 
 ARG UID=1000
 ARG GID=1000
@@ -8,13 +9,27 @@ ENV KBUILD_BUILD_HOST "kernel-builder"
 
 RUN apt-get update && \
     apt-get install -y \
-    git fakeroot build-essential ncurses-dev xz-utils libssl-dev bc wget \
-    flex curl bison rsync kmod cpio libelf-dev liblz4-tool
-
-RUN apt-get install -y python3 python3-requests
-RUN apt-get install -y gnupg
-RUN apt-get install -y gcc-8-plugin-dev
-RUN apt-get install -y lsb-release
+    bc \
+    bison \
+    build-essential \
+    cpio \
+    curl \
+    fakeroot \
+    flex \
+    gcc-8-plugin-dev \
+    git \
+    gnupg \
+    kmod \
+    libelf-dev \
+    liblz4-tool \
+    libssl-dev \
+    lsb-release \
+    ncurses-dev \
+    python3 \
+    python3-requests \
+    rsync \
+    wget \
+    xz-utils
 
 RUN groupadd -g ${GID} ${USERNAME} && useradd -m -d /home/${USERNAME} -g ${GID} -u ${UID} ${USERNAME}
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .DEFAULT_GOAL := help
-IMG_NAME = quay.io/conorsch/kernel-builder
+IMG_NAME = fpf.local/kernel-builder
 
 .PHONY: vanilla
 vanilla: ## Builds latest stable kernel, unpatched
 	# Include reproducibility patch, for Debian changelog timestamp
 	LINUX_LOCAL_PATCHES_PATH="$(PWD)/patches/00-debian-reproducibility.patch" \
-	./scripts/build-kernel-wrapper
+		./scripts/build-kernel-wrapper
 
 .PHONY: grsec
 grsec: ## Builds grsecurity-patched kernel (requires credentials)
@@ -21,9 +21,6 @@ reprotest-sd: ## DEBUG Builds SD kernel config without grsec in CI
 		LINUX_LOCAL_CONFIG_PATH="$(PWD)/configs/config-securedrop-5.4" \
 		LINUX_LOCAL_PATCHES_PATH="$(PWD)/patches" \
 		./scripts/reproducibility-test
-
-build-image: ## Builds container image
-	docker build -t $(IMG_NAME) .
 
 securedrop-core: build-image ## Builds kernels for SecureDrop servers, 5.4.x
 	GRSECURITY=1 GRSECURITY_PATCH_TYPE=stable4 LOCALVERSION="-securedrop" \

--- a/README.md
+++ b/README.md
@@ -38,12 +38,19 @@ at `/config` inside the container. It will be copied into place prior to buildin
 Note that `make olddefconfig` will be run regardless to ensure the latest
 options have been applied.
 
-## Where on my files?
-Check `./build/` on the host machine. You can mount any directory to `/output`
-inside the container, and that's where the packages will be stored. By default,
-the build script attempts to save `.deb` packages and `.tar.gz`, the source tarball.
+## Reproducibile builds
+In the spirit of [reproducible builds], this repo attempts to make fully reproducible
+kernel images. There are some catches, however: a custom kernel patch is included
+to munge the changelog timestamp, and certain kernel config options (notably 
+`CONFIG_GCC_PLUGIN_RANDSTRUCT` or `CONFIG_GRKERNSEC_RANDSTRUCT`) will prevent reproducibility.
+For more info, see the [kernel docs on reproducibility].
 
-## Rereferences
+Additionally, the script to fetch grsecurity patches works by choosing the most recent patch
+available. If you wish to rebuild an older kernel version, you'll need to rebuild from the
+original source tarball, and set environment variables such as `SOURCE_DATE_EPOCH`. Even then,
+structure randomization may prevent an identical build.
+
+## References
 
 These configurations were developed by [Freedom of the Press Foundation] for
 use in all [SecureDrop] instances. Experienced sysadmins can leverage these
@@ -56,3 +63,5 @@ https://github.com/freedomofpress/ansible-role-grsecurity-build/.
 [SecureDrop]: https://securedrop.org
 [grsecurity]: https://grsecurity.net/
 [grsecurity subscription]: https://grsecurity.net/business_support.php
+[reproducible builds]: https://reproducible-builds.org/
+[kernel docs on reproducibility]: https://www.kernel.org/doc/html/latest/kbuild/reproducible-builds.html

--- a/scripts/build-kernel-wrapper
+++ b/scripts/build-kernel-wrapper
@@ -12,6 +12,14 @@ export SOURCE_DATE_EPOCH
 export KBUILD_BUILD_TIMESTAMP="@${SOURCE_DATE_EPOCH}"
 export DEB_BUILD_TIMESTAMP="${SOURCE_DATE_EPOCH}"
 
+# Build container image for kernel dependencies
+IMG_NAME="fpf.local/kernel-builder"
+docker build -t "$IMG_NAME" \
+    --build-arg UID="$(id -u)" \
+    --build-arg GID="$(id -g)" \
+    .
+
+# Configure local customizations
 local_config_volume_opt=""
 if [[ -n "${LINUX_LOCAL_CONFIG_PATH:-}" ]]; then
     local_config_volume_opt="-v ${LINUX_LOCAL_CONFIG_PATH}:/config:ro"
@@ -21,13 +29,9 @@ if [[ -n "${LINUX_LOCAL_PATCHES_PATH:-}" ]]; then
     local_patches_volume_opt="-v ${LINUX_LOCAL_PATCHES_PATH}:/patches:ro"
 fi
 
-img_name="quay.io/conorsch/kernel-builder"
+# Create output dir
 kernel_dir="$PWD/build"
 mkdir -p -m 755 "$kernel_dir"
-docker build -t "$img_name" \
-    --build-arg UID="$(id -u)" \
-    --build-arg GID="$(id -g)" \
-    .
 
 docker run --rm -t \
     -e GRSECURITY_USERNAME \
@@ -41,7 +45,7 @@ docker run --rm -t \
     -v "${kernel_dir}:/output" \
     $local_config_volume_opt \
     $local_patches_volume_opt \
-    "$img_name"
+    "$IMG_NAME"
 
 echo "Build complete. Packages can be found at:"
 find "$kernel_dir" -type f | sort


### PR DESCRIPTION
Using reliable ol' Debian Stable. Consolidates apt dependencies, squashing them all down into a single layer, since the build logic is
stable now. Adjusts container names where appropriate, and touches up the README, as well.