### PR TITLE
Fixes SD build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,18 +22,18 @@ reprotest-sd: ## DEBUG Builds SD kernel config without grsec in CI
 		LINUX_LOCAL_PATCHES_PATH="$(PWD)/patches" \
 		./scripts/reproducibility-test
 
-securedrop-core: build-image ## Builds kernels for SecureDrop servers, 5.4.x
+securedrop-core: ## Builds kernels for SecureDrop servers, 5.4.x
 	GRSECURITY=1 GRSECURITY_PATCH_TYPE=stable4 LOCALVERSION="-securedrop" \
 		LINUX_LOCAL_CONFIG_PATH="$(PWD)/configs/config-securedrop-5.4" \
 		LINUX_LOCAL_PATCHES_PATH="$(PWD)/patches" \
 		./scripts/build-kernel-wrapper
 
-securedrop-core-4.14: build-image ## Builds kernels for SecureDrop servers, 4.14.x
+securedrop-core-4.14: ## Builds kernels for SecureDrop servers, 4.14.x
 	GRSECURITY=1 GRSECURITY_PATCH_TYPE=stable3 LOCALVERSION="-securedrop" \
 		LINUX_LOCAL_CONFIG_PATH="$(PWD)/configs/config-securedrop-4.14" \
 		./scripts/build-kernel-wrapper
 
-securedrop-workstation: build-image ## Builds kernels for SecureDrop Workstation
+securedrop-workstation: ## Builds kernels for SecureDrop Workstation
 	GRSECURITY=1 GRSECURITY_PATCH_TYPE=stable3 LOCALVERSION="-workstation" \
 		LINUX_LOCAL_CONFIG_PATH="$(PWD)/configs/config-workstation-4.14" \
 		./scripts/build-kernel-wrapper

--- a/scripts/build-kernel-wrapper
+++ b/scripts/build-kernel-wrapper
@@ -33,6 +33,9 @@ fi
 kernel_dir="$PWD/build"
 mkdir -p -m 755 "$kernel_dir"
 
+# TODO: It'd be great to pass `-i` here so the builds can be cancelled,
+# but that breaks reprotest. Pass it conditionally, depending on whether
+# there's an interactive session available.
 docker run --rm -t \
     -e GRSECURITY_USERNAME \
     -e GRSECURITY_PASSWORD \


### PR DESCRIPTION
Follow-up to #10, a script refactor. Those redundant "build-image" targets aren't used anymore, it's built into the script.