### PR TITLE
Allow building on a machine with SELinux

### DIFF
--- a/scripts/build-kernel-wrapper
+++ b/scripts/build-kernel-wrapper
@@ -45,7 +45,7 @@ docker run --rm -t \
     -e KBUILD_BUILD_TIMESTAMP \
     -e DEB_BUILD_TIMESTAMP \
     -e LOCALVERSION \
-    -v "${kernel_dir}:/output" \
+    -v "${kernel_dir}:/output:Z" \
     $local_config_volume_opt \
     $local_patches_volume_opt \
     "$IMG_NAME"


### PR DESCRIPTION
On machines with SELinux enabled, folder labels need to be set correctly for the container to be allowed to write to it. `:Z` relabels the appropriate folders automatically on start.

(Note: unsigned commit due to intermittent issues with `gpg` right now. Can sign and force-push if that is warranted)