### PR TITLE
Fix versioning to match what unattended-upgrades wants; force removal of old kernels

### DIFF
--- a/build-kernel.sh
+++ b/build-kernel.sh
@@ -89,7 +89,7 @@ echo "Building Linux kernel source $LINUX_VERSION"
 make olddefconfig
 
 VCPUS="$(nproc)"
-make -j $VCPUS deb-pkg
+make EXTRAVERSION="-1" -j $VCPUS deb-pkg
 
 echo "Storing build artifacts for $LINUX_VERSION"
 if [[ -d /output ]]; then

--- a/scripts/mkdebian
+++ b/scripts/mkdebian
@@ -224,7 +224,8 @@ cat <<EOF >> debian/control
 Package: securedrop-grsec
 Section: admin
 Architecture: $debarch
-Depends: $packagename-$version, intel-microcode, paxctld
+Depends: $packagename-$version, intel-microcode, paxctld,
+ linux-image-5.15.89-grsec-securedrop
 Description: Metapackage providing a grsecurity-patched Linux kernel for use
  with SecureDrop. Depends on the most recently built patched kernel maintained
  by FPF. Package also includes sysctl and PaX flags calls for GRUB.


### PR DESCRIPTION
Note: this depends on #34 to be merged first.

----

unattended-upgrades has a regex that expects the kernel package name
to have a package version in it, e.g. ending with "-1".
    
Previously:
```
Name: linux-image-5.15.89-grsec-securedrop
Version: 5.15.89-grsec-securedrop-1
```    
Now:
```
Name: linux-image-5.15.89-1-grsec-securedrop
Version: 5.15.89-1-grsec-securedrop-1
```

Then, since we want to keep the previous kernel, set a temporary explicit dependency on it so unattended-upgrades doesn't remove it.

Refs https://github.com/freedomofpress/securedrop/issues/6762.