### PR TITLE
Install amd64-microcode too

### DIFF
--- a/scripts/mkdebian
+++ b/scripts/mkdebian
@@ -224,7 +224,7 @@ cat <<EOF >> debian/control
 Package: securedrop-grsec
 Section: admin
 Architecture: $debarch
-Depends: $packagename-$version, intel-microcode, paxctld,
+Depends: $packagename-$version, intel-microcode, amd64-microcode, paxctld,
  linux-image-5.15.89-grsec-securedrop
 Description: Metapackage providing a grsecurity-patched Linux kernel for use
  with SecureDrop. Depends on the most recently built patched kernel maintained


### PR DESCRIPTION
Make sure that anyone running SecureDrop on AMD processors is getting microcode updates. This will be a no-op for machines with Intel processors (just like intel-microcode is a no-op for AMD).