### PR TITLE
Revert "Explicitly depend on linux-image-5.15.89-grsec-securedrop (temporarily)"

### DIFF
--- a/scripts/mkdebian
+++ b/scripts/mkdebian
@@ -224,8 +224,7 @@ cat <<EOF >> debian/control
 Package: securedrop-grsec
 Section: admin
 Architecture: $debarch
-Depends: $packagename-$version, intel-microcode, amd64-microcode, paxctld,
- linux-image-5.15.89-grsec-securedrop
+Depends: $packagename-$version, intel-microcode, amd64-microcode, paxctld
 Description: Metapackage providing a grsecurity-patched Linux kernel for use
  with SecureDrop. Depends on the most recently built patched kernel maintained
  by FPF. Package also includes sysctl and PaX flags calls for GRUB.


### PR DESCRIPTION
This was only needed for one kernel release as we switch to the new versioning schema and can now be removed.

This reverts commit 96c597a9d50a44d82c0602b1c0b04ecc04f18293.