### PR TITLE
build: wrap `build-kernel-wrapper` in `script`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,25 @@
 .DEFAULT_GOAL := help
 IMG_NAME = fpf.local/kernel-builder
+SCRIPT_OUTPUT_PREFIX=$(PWD)/build/$(shell date +%Y%m%d)
+SCRIPT_OUTPUT_EXT=log
 
 .PHONY: vanilla
+vanilla: OUT:=$(SCRIPT_OUTPUT_PREFIX)-vanilla.$(SCRIPT_OUTPUT_EXT)
 vanilla: ## Builds latest stable kernel, unpatched
-	LINUX_MAJOR_VERSION="5.15" ./scripts/build-kernel-wrapper
+	LINUX_MAJOR_VERSION="5.15" \
+		script \
+		--command ./scripts/build-kernel-wrapper \
+		--return \
+		$(OUT)
 
 .PHONY: grsec
+grsec: OUT:=$(SCRIPT_OUTPUT_PREFIX)-grsec.$(SCRIPT_OUTPUT_EXT)
 grsec: ## Builds grsecurity-patched kernel (requires credentials)
-	GRSECURITY=1 ./scripts/build-kernel-wrapper
+	GRSECURITY=1 \
+		script \
+		--command ./scripts/build-kernel-wrapper \
+		--return \
+		$(OUT)
 
 .PHONY: reprotest
 reprotest: ## Builds simple kernel multiple times to confirm reproducibility
@@ -20,16 +32,24 @@ reprotest-sd: ## DEBUG Builds SD kernel config without grsec in CI
 		LINUX_LOCAL_PATCHES_PATH="$(PWD)/patches" \
 		./scripts/reproducibility-test
 
+securedrop-core-5.15: OUT:=$(SCRIPT_OUTPUT_PREFIX)-securedrop-core-5.15.$(SCRIPT_OUTPUT_EXT)
 securedrop-core-5.15: ## Builds kernels for SecureDrop servers, 5.15.x
 	GRSECURITY=1 GRSECURITY_PATCH_TYPE=stable6 LOCALVERSION="-securedrop" \
 		LINUX_LOCAL_CONFIG_PATH="$(PWD)/configs/config-securedrop-5.15" \
 		LINUX_LOCAL_PATCHES_PATH="$(PWD)/patches" \
-		./scripts/build-kernel-wrapper
+		script \
+		--command ./scripts/build-kernel-wrapper \
+		--return \
+		$(OUT)
 
+securedrop-workstation-5.15: OUT:=$(SCRIPT_OUTPUT_PREFIX)-securedrop-workstation-5.15.$(SCRIPT_OUTPUT_EXT)
 securedrop-workstation-5.15: ## Builds kernels for SecureDrop Workstation, 5.15.x
 	GRSECURITY=1 GRSECURITY_PATCH_TYPE=stable6 LOCALVERSION="-workstation" \
 		LINUX_LOCAL_CONFIG_PATH="$(PWD)/configs/config-workstation-5.15" \
-		./scripts/build-kernel-wrapper
+		script \
+		--command ./scripts/build-kernel-wrapper \
+		--return \
+		$(OUT)
 
 .PHONY: help
 help: ## Prints this message and exits.

--- a/scripts/build-kernel-wrapper
+++ b/scripts/build-kernel-wrapper
@@ -11,6 +11,7 @@ SOURCE_DATE_EPOCH="1309379017"
 export SOURCE_DATE_EPOCH
 export KBUILD_BUILD_TIMESTAMP="@${SOURCE_DATE_EPOCH}"
 export DEB_BUILD_TIMESTAMP="${SOURCE_DATE_EPOCH}"
+export TERM=dumb  # to omit control characters from "script" transcripts
 
 # Build container image for kernel dependencies
 IMG_NAME="fpf.local/kernel-builder"
@@ -46,6 +47,7 @@ docker run --rm -t \
     -e DEB_BUILD_TIMESTAMP \
     -e LINUX_MAJOR_VERSION \
     -e LOCALVERSION \
+    -e TERM \
     -v "${kernel_dir}:/output:Z" \
     $local_config_volume_opt \
     $local_patches_volume_opt \


### PR DESCRIPTION
Just like freedomofpress/securedrop#6787, wraps the existing wrapper script in `script` so that the build log (transcript) is saved automatically.

## Checklist

I'll test this in the course of freedomofpress/securedrop#6938 and freedomofpress/securedrop-workstation#916.  For formal review:

- [ ] CI passes.
- [ ] `make {vanilla,grsec,securedrop-core-5.15,securedrop-workstation-5.15}` succeed and produce the expected build logs in `build/`.