### PR TITLE
Correctly identify metapackage for server builds

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,8 +20,8 @@ ifneq (,$(filter-out parallel=1,$(filter parallel=%,$(DEB_BUILD_OPTIONS))))
 endif
 
 # Get the metapackage name by listing the packages from d/control and
-# picking the only one that starts with SD
-METAPACKGE := $(shell dh_listpackages | grep "securedrop")
+# picking the only one that starts with "securedrop"
+METAPACKGE := $(shell dh_listpackages | grep "^securedrop")
 
 .PHONY: binary binary-indep binary-arch
 binary: binary-arch binary-indep


### PR DESCRIPTION
## Status

Ready for review

## Description

The server kernel uses "securedrop" as the version label, so it appears in all packages. Fix the regex to only look for "securedrop-" packages as the metapackage (as the comment correctly described).

Fixes #50.

## Test plan

* [x] Visual review
* [x] Successfully build a server kernel with `make securedrop-core-5.15` - done with https://github.com/freedomofpress/securedrop-apt-test/pull/235.