### PR TITLE
Set net.ipv4 sysctl flags via server metapackage

### DIFF
--- a/debian/securedrop-grsec/DEBIAN/postinst
+++ b/debian/securedrop-grsec/DEBIAN/postinst
@@ -42,12 +42,21 @@ start_paxctld() {
     sleep 1
 }
 
+cleanup_sysctld() {
+    # Remove settings previously set by ansible that are now set via
+    # our sysctl.d/30-securedrop.conf file
+    sed -i '/^vm\.heap_stack_gap/d' /etc/sysctld.conf
+    sed -i '/^net\.ipv4\./d' /etc/sysctld.conf
+}
+
 case "$1" in
     configure)
     # Configure paxctld, required before update-grub runs
     start_paxctld
     # Ensure latest grsec kernel is used on every boot.
     set_grub_default
+    # Remove sysctld configuration
+    cleanup_sysctld
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/securedrop-grsec/etc/sysctl.d/30-securedrop.conf
+++ b/debian/securedrop-grsec/etc/sysctl.d/30-securedrop.conf
@@ -1,1 +1,16 @@
 vm.heap_stack_gap=1048576
+
+net.ipv4.tcp_max_syn_backlog = 4096
+net.ipv4.tcp_syncookies = 1
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.all.secure_redirects = 0
+net.ipv4.conf.default.rp_filter = 1
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.default.secure_redirects = 0
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.ip_forward = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0


### PR DESCRIPTION
Instead of setting these via ansible, let's ship them in this package so it's easier to tweak them in the future without needing future ansible runs.

A postinst snippet removes the values from /etc/sysctld.conf; it's okay if they're temporarily duplicated since they'll have the same values.

Refs <https://github.com/freedomofpress/securedrop/issues/7323>.