### PR TITLE
Check /etc/sysctld.conf exists before trying to edit it in postinst

### DIFF
--- a/debian/securedrop-grsec/DEBIAN/postinst
+++ b/debian/securedrop-grsec/DEBIAN/postinst
@@ -45,8 +45,10 @@ start_paxctld() {
 cleanup_sysctld() {
     # Remove settings previously set by ansible that are now set via
     # our sysctl.d/30-securedrop.conf file
-    sed -i '/^vm\.heap_stack_gap/d' /etc/sysctld.conf
-    sed -i '/^net\.ipv4\./d' /etc/sysctld.conf
+    if [[ -f /etc/sysctld.conf ]]; then
+        sed -i '/^vm\.heap_stack_gap/d' /etc/sysctld.conf
+        sed -i '/^net\.ipv4\./d' /etc/sysctld.conf
+    fi
 }
 
 case "$1" in


### PR DESCRIPTION
During server install, the /etc/sysctld.conf file won't have been created by ansible at the time the kernel is being installed.