### PR TITLE
Include checksums in build log

### DIFF
--- a/scripts/build-kernel-wrapper
+++ b/scripts/build-kernel-wrapper
@@ -61,3 +61,6 @@ docker run --rm $DOCKER_RUN_ARGUMENTS \
 
 echo "Build complete. Packages can be found at:"
 find "$kernel_dir" -type f | sort
+
+echo "And sha256sums are:"
+find "$kernel_dir" -type f \( -name "*.deb" -o -name "*.buildinfo" -o -name "*.orig.tar.xz" \) -exec sha256sum {} \;


### PR DESCRIPTION
Reviewing https://github.com/freedomofpress/securedrop-apt-prod/pull/166 I noticed that we don't include artifact checksums in the build log captured by `script`, so include sha256sums for the .deb, the .orig.tar.gz, and the .buildinfo file in the build logs.

**Test plan**
- [ ] Visual review
- [ ] CI (see [example output](https://github.com/freedomofpress/kernel-builder/actions/runs/14042776195/job/39316635191#step:4:4446))