### PR TITLE
fix: fail if `grsecurity-urls.py` returns nonzero

### DIFF
--- a/build-kernel.py
+++ b/build-kernel.py
@@ -53,7 +53,7 @@ def main():
         print("Will include grsecurity patch for kernel", linux_version)
         with open("/patches-grsec/grsec", "wb") as f:
             # TODO: invoke this through normal Python means
-            subprocess.run(["/usr/local/bin/grsecurity-urls.py"], stdout=f)
+            subprocess.run(["/usr/local/bin/grsecurity-urls.py"], stdout=f, check=True)
     else:
         print("Skipping grsecurity patch set")
 


### PR DESCRIPTION
Trivially fixes #62.  Further linting deferred to #63 after this lands to unblock freedomofpress/securedrop#7511.

To test:

```sh-session
$ GRSECURITY=1 make core-5.15
[...]
Will include grsecurity patch for kernel 5.15.181
2025-05-06 23:40:42 ERROR    Credentials not found, set GRSECURITY_USERNAME & GRSECURITY_PASSWORD
Traceback (most recent call last):
  File "/usr/local/bin/build-kernel.py", line 180, in <module>
    main()
  File "/usr/local/bin/build-kernel.py", line 56, in main
    subprocess.run(["/usr/local/bin/grsecurity-urls.py"], stdout=f, check=True)
  File "/usr/lib/python3.7/subprocess.py", line 487, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/local/bin/grsecurity-urls.py']' returned non-zero exit status 1.
Script done.
make: *** [Makefile:49: securedrop-core-5.15] Error 1
```