### PR TITLE
Add xen_privcmd.unrestricted to workstation kernel opts

### DIFF
--- a/debian/securedrop-workstation-grsec/etc/default/grub.d/60-unrestrict-privcmd.cfg
+++ b/debian/securedrop-workstation-grsec/etc/default/grub.d/60-unrestrict-privcmd.cfg
@@ -1,0 +1,3 @@
+# set xen_privcmd to unrestricted to account for XSA-482 patch
+# see https://github.com/QubesOS/qubes-linux-kernel/pull/1256
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX xen_privcmd.unrestricted"


### PR DESCRIPTION
Adds `xen_privcmd.unrestricted` to the boot options for the workstation kernel, to work around fixes for XSA-482 that are not security-relevant for Qubes.

# Test plan
- [x] Visual review confirming the .cfg file is correctly formatted is sufficient
- [ ] extra points - run `make securedrop-workstation-6.6` and verify the additional grub.cfg file is present in the securedrop-workstation-grsec package
- [ ] super extra points - as above but also install the kernel in an SDW template and verify that it boots.