### PR TITLE
Use trixie instead of bookworm in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
   reproducible:
     runs-on: ubuntu-latest
-    container: debian:bookworm
+    container: debian:trixie
     needs:
       - build
     strategy:


### PR DESCRIPTION
Fixes #82.

## Test plan
* [x] CI passes
* [x] bookworm isn't mentioned in .github/workflows